### PR TITLE
simplify latency alignment process

### DIFF
--- a/econt_sw/testing/utils/link_capture.py
+++ b/econt_sw/testing/utils/link_capture.py
@@ -91,7 +91,6 @@ class LinkCapture:
         """Reset links and set latency for multiple lcs"""
         for lcapture in lcaptures:
             for l in range(self.nlinks[lcapture]):
-                self.dev.getNode(self.lcs[lcapture]+".link"+str(l)+".explicit_resetb").write(0)
                 self.dev.getNode(self.lcs[lcapture]+".link"+str(l)+".fifo_latency").write(latency[l]);
             self.dev.dispatch()
             self.logger.debug(f'Written latencies in {lcapture}: %s',latency)


### PR DESCRIPTION
Changes the latency alignment procedure, simplifying things.

Instead of scanning over latency settings, we now simply set the latency of the ASIC and emulator to 0 in all channels, capture data from LinkResetECONT, locate the BX0 word in the data, then calculate and set the latency as needed.